### PR TITLE
feat(navbar): add responsive blog title

### DIFF
--- a/src/app/api/comments/route.tsx
+++ b/src/app/api/comments/route.tsx
@@ -1,5 +1,4 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { UserRole } from "@prisma/client";
 import prisma from "@/utils/connect";
 import { labels } from "@/views/labels";
 import { currentUser, currentRole } from "@/lib/currentUser";

--- a/src/components/organisms/Navbar/Navbar.tsx
+++ b/src/components/organisms/Navbar/Navbar.tsx
@@ -24,7 +24,10 @@ export const Navbar = ({ children }: { children: React.ReactNode }) => {
 				<Image src="/tiktok.png" alt="tiktokIcon" width={24} height={24} />
 				<Image src="/youtube.png" alt="youtubeIcon" width={24} height={24} />
 			</div>
-			<div className="logo">{labels.fullBlogTitle}</div>
+			<div className="logo">
+				<span className="full-title">{labels.fullBlogTitle}</span>
+				<span className="short-title">{labels.shortBlogTitle}</span>
+			</div>
 			<div className="links">
 				<ThemeToggle />
 				<Link href="/" className="link">

--- a/src/components/organisms/Navbar/navbar.css
+++ b/src/components/organisms/Navbar/navbar.css
@@ -87,3 +87,21 @@
 		display: none;
 	}
 }
+
+.logo .full-title {
+	display: block;
+}
+
+.logo .short-title {
+	display: none;
+}
+
+@media screen and (max-width: 43.75rem) {
+	.logo .full-title {
+		display: none;
+	}
+
+	.logo .short-title {
+		display: block;
+	}
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -25,6 +25,10 @@ const config = {
 
 			sm: { max: "639px" },
 			// => @media (max-width: 639px) { ... }
+
+			xs: { max: "420px" },
+			
+			mobile: { max: "700px" },
 		},
 		container: {
 			center: true,


### PR DESCRIPTION
Add short version of blog title for mobile screens:
- Add full-title and short-title spans in Navbar component
- Add CSS styles to handle title switching at 43.75rem breakpoint
- Keep existing font size adjustments for different screen sizes