### PR TITLE
fix: add blog and category paths to public routes

### DIFF
--- a/routes.ts
+++ b/routes.ts
@@ -1,4 +1,4 @@
-export const publicRoutes = ["/", "/new-verification", "/api/categories", "/api/posts", "/posts", "/api/comments"];
+export const publicRoutes = ["/", "/new-verification", "/api/categories", "/api/posts", "/posts", "/api/comments", "/blog", "/category/:path*"];
 
 export const authRoutes = ["/login", "/register", "/error", "/reset", "/new-password"];
 


### PR DESCRIPTION
- Add /blog and /category/:path* to publicRoutes array
- Allow unauthenticated users to access blog categories