### PR TITLE
fix: preserve category parameter in pagination URLs

### DIFF
--- a/src/components/molecules/Pagination/Pagination.tsx
+++ b/src/components/molecules/Pagination/Pagination.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import "./pagination.css";
 import { labels } from "@/views/labels";
 
@@ -13,13 +13,15 @@ interface Pagination {
 
 export const Pagination = ({ page, hasPrev, hasNext, maxPage }: Pagination) => {
 	const router = useRouter();
+	const searchParams = useSearchParams();
+	const cat = searchParams.get("cat");
 
 	return (
 		<div className="pagination">
 			<button
 				className="pagination__button"
 				disabled={!hasPrev}
-				onClick={() => router.push(`?page=${page - 1}`)}
+				onClick={() => router.push(`?page=${page - 1}${cat ? `&cat=${cat}` : ""}`)}
 			>
 				{labels.previous}
 			</button>
@@ -27,7 +29,7 @@ export const Pagination = ({ page, hasPrev, hasNext, maxPage }: Pagination) => {
 			<button
 				className="pagination__button"
 				disabled={!hasNext}
-				onClick={() => router.push(`?page=${page + 1}`)}
+				onClick={() => router.push(`?page=${page + 1}${cat ? `&cat=${cat}` : ""}`)}
 			>
 				{labels.next}
 			</button>


### PR DESCRIPTION
- Add useSearchParams hook to get category from URL
- Update pagination buttons to maintain category parameter when changing pages