### PR TITLE
fix: align client-side caching with API cache-control

### DIFF
--- a/src/utils/services/popularPosts/request.tsx
+++ b/src/utils/services/popularPosts/request.tsx
@@ -3,7 +3,7 @@ import { getBaseUrl } from "@/utils/config";
 
 export const getPopularPosts = async (): Promise<PromiseGetData[]> => {
 	const res = await fetch(`${getBaseUrl}/api/posts/popular`, {
-		cache: "no-store",
+		next: { revalidate: 10 }
 	});
 
 	if (!res.ok) {


### PR DESCRIPTION
- Update getPopularPosts to use revalidate: 10 to match API cache settings
- Remove no-store to enable proper caching behavior